### PR TITLE
Håndtere feil verdier til Enum i request-body, slik at appliksajon re…

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/iatjenester/metrikker/RestResponseEntityExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/iatjenester/metrikker/RestResponseEntityExceptionHandler.kt
@@ -11,6 +11,7 @@ import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnaut
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseBody
@@ -58,6 +59,17 @@ class RestResponseEntityExceptionHandler {
     protected fun handleResponseStatusException(e: ResponseStatusException, webRequest: WebRequest?): ResponseEntity<Any> {
         log.warn(e.message, e)
         return getResponseEntity(e, e.message, e.status)
+    }
+
+    @ExceptionHandler(value = [HttpMessageNotReadableException::class])
+    @ResponseBody
+    protected fun handleRequestParsingException(e: HttpMessageNotReadableException, webRequest: WebRequest?): ResponseEntity<Any> {
+        log.info(e.message, e)
+        return getResponseEntity(
+            e,
+            "Innhold til request er ikke gyldig (feil ved parsing av request body)",
+            HttpStatus.BAD_REQUEST
+        )
     }
 
     @ExceptionHandler(value = [Exception::class])

--- a/src/test/kotlin/no/nav/arbeidsgiver/iatjenester/metrikker/TestUtils.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/iatjenester/metrikker/TestUtils.kt
@@ -71,6 +71,18 @@ class TestUtils {
         """.trimIndent()
         }
 
+        fun ugyldigInnloggetIaTjenesteAsString(orgnr: String? = ORGNR_SOM_RETURNERES_AV_MOCK_ALTINN): String {
+            return """
+            {
+              "orgnr":"$orgnr",
+              "altinnRettighet":"${AltinnRettighet.ARBEIDSGIVERS_OPPFØLGINGSPLAN_FOR_SYKMELDTE.name}",
+              "kilde":"SYKEFRAVÆRSSTATISTIKK",
+              "type":"drop table innlogget_ia_tjenester",
+              "tjenesteMottakkelsesdato":"2021-03-11T18:48:38Z"
+            }
+        """.trimIndent()
+        }
+
         fun Connection.cleanTable(tableName: String) =
             use {
                 this.prepareStatement(


### PR DESCRIPTION
…turnerer 400 i stedet av 500 (og uhåndtert feil)
Med denne endringen vil applikasjonen feile på en litt bedre måte (med en 400 - BAD REQUEST) dersom POST til ia-tjenester-metrrikker inneholder ugyldig data (særlig ved Enum validering) 
Oppdaget ifm hacke-dag